### PR TITLE
feat: added python callout example for model armor

### DIFF
--- a/callouts/python/extproc/example/model_armor/README.md
+++ b/callouts/python/extproc/example/model_armor/README.md
@@ -1,0 +1,120 @@
+# Setting Up Traffic Extension with Model Armor Callout Backend
+
+## Prerequisites
+
+- Docker image for Model Armor Callout backend pushed to a registry.
+
+To create the Docker image, run the following command from the callout Python root directory:
+```bash
+docker build \
+  -f ./extproc/example/Dockerfile \
+  -t model-armour-callout-python \
+  --build-arg copy_path=extproc/example/model_armor/ \
+  --build-arg run_module=service_callout_example .
+```
+For more information, refer to the Service Extensions documentation.
+
+## Setup Guide
+1. Configure VPC for Load Balancer and Backend VMs. Follow the Google Cloud [guide](https://cloud.google.com/load-balancing/docs/l7-internal/setting-up-l7-internal#configure-a-network) to set up your VPC.
+
+```bash
+# Example commands (adjust as needed)
+gcloud compute networks create my-network --subnet-mode=custom
+gcloud compute networks subnets create my-subnet \
+    --network=my-network --range=10.0.0.0/24 --region=us-central1
+```
+
+2. Set up Firewall Rules
+Configure firewall rules for backends (Google Cloud [documentation](https://cloud.google.com/load-balancing/docs/l7-internal/setting-up-l7-internal#configure_firewall_rules)).
+```bash
+# Example firewall rule
+gcloud compute firewall-rules create allow-health-check \
+    --network=my-network \
+    --action=allow \
+    --direction=ingress \
+    --source-ranges=130.211.0.0/22,35.191.0.0/16 \
+    --target-tags=allow-health-check \
+    --rules=tcp:80
+```
+
+3. Reserve IP Address for Load Balancer (Optional)
+If needed, reserve an internal IP address following these [instructions](https://cloud.google.com/load-balancing/docs/l7-internal/setting-up-l7-internal#reserve-ip).
+```bash
+gcloud compute addresses create my-ilb-ip \
+    --region=us-central1 \
+    --subnet=my-subnet
+```
+
+4. Create LLM Backend
+Set up a managed instance group for your LLM backend. Refer to the Google Cloud [guide](https://cloud.google.com/load-balancing/docs/l7-internal/setting-up-l7-internal#create-instance-group-backend) for details.
+
+```bash
+# Example commands for creating an instance template and managed instance group
+gcloud compute instance-templates create llm-template \
+    --machine-type=n1-standard-2 \
+    --image-family=debian-10 \
+    --image-project=debian-cloud \
+    --tags=allow-health-check
+
+gcloud compute instance-groups managed create llm-mig \
+    --template=llm-template \
+    --size=2 \
+    --zone=us-central1-a
+```
+
+5. Configure Load Balancer
+Create a load balancer to distribute traffic to your LLM backend. You can set up different URL maps for multiple backends if required. Follow the load balancer configuration [guide](https://cloud.google.com/load-balancing/docs/l7-internal/setting-up-l7-internal#lb-config) for more information.
+
+```bash
+# Example commands for setting up a load balancer
+gcloud compute health-checks create http llm-health-check --port 80
+
+gcloud compute backend-services create llm-backend-service \
+    --load-balancing-scheme=internal \
+    --protocol=http \
+    --health-checks=llm-health-check \
+    --region=us-central1
+
+gcloud compute backend-services add-backend llm-backend-service \
+    --instance-group=llm-mig \
+    --instance-group-zone=us-central1-a \
+    --region=us-central1
+
+gcloud compute url-maps create llm-url-map \
+    --default-service llm-backend-service \
+    --region=us-central1
+
+gcloud compute target-http-proxies create llm-proxy \
+    --url-map=llm-url-map \
+    --region=us-central1
+
+gcloud compute forwarding-rules create llm-forwarding-rule \
+    --load-balancing-scheme=internal \
+    --network=my-network \
+    --subnet=my-subnet \
+    --address=my-ilb-ip \
+    --ports=80 \
+    --target-http-proxy=llm-proxy \
+    --target-http-proxy-region=us-central1 \
+    --region=us-central1
+```
+
+6. Set Up Client Instance
+Create a client instance that can interact with the load-balanced LLM backend. Refer to the testing VM setup [guide](https://cloud.google.com/load-balancing/docs/l7-internal/setting-up-l7-internal#test_client).
+```bash
+gcloud compute instances create test-vm \
+    --zone=us-central1-a \
+    --subnet=my-subnet \
+    --no-address
+```
+
+## Configuring Callout Backend for Service Extension
+
+1. Create Callout Server Instance
+Set up an instance for the Model Armor callout server. Follow the Google Cloud [guide](https://cloud.google.com/service-extensions/docs/configure-callout-backend-service#configure-extension-service) to create the instance, instance group, and backend service.
+
+**Note:** When creating the callout instance, ensure that the appropriate Cloud API score is enabled for the Model Armor service in the "Security and Access" settings.
+
+2. Configure Traffic Extension
+Create a traffic extension for the Model Armor callout backend service using the Google Cloud [documentation](https://cloud.google.com/service-extensions/docs/configure-traffic-extensions#configure_a_traffic_extension_by_using_a_callout).
+

--- a/callouts/python/extproc/example/model_armor/README.md
+++ b/callouts/python/extproc/example/model_armor/README.md
@@ -1,5 +1,10 @@
 # Setting Up Traffic Extension with Model Armor Callout Backend
 
+This guide outlines the necessary steps to integrate a traffic extension with a Python callout using the Model Armor APIs to sanitize prompts or model responses effectively in the application load balancer. Before diving into the setup process, it is recommended to familiarize yourself with the following concepts:
+- [Model Armor](https://cloud.google.com/security-command-center/docs/model-armor-overview)
+- [Service Extensions](https://cloud.google.com/service-extensions/docs/overview)
+- [Callouts](https://cloud.google.com/service-extensions/docs/callouts-overview)
+
 ## Prerequisites
 
 - Docker image for Model Armor Callout backend pushed to a registry.
@@ -12,109 +17,142 @@ docker build \
   --build-arg copy_path=extproc/example/model_armor/ \
   --build-arg run_module=service_callout_example .
 ```
-For more information, refer to the Service Extensions documentation.
+For more information, refer to the [Docker guide](../../../README.md#docker) of Server Extension python callouts.
 
 ## Setup Guide
 1. Configure VPC for Load Balancer and Backend VMs. Follow the Google Cloud [guide](https://cloud.google.com/load-balancing/docs/l7-internal/setting-up-l7-internal#configure-a-network) to set up your VPC.
 
-```bash
-# Example commands (adjust as needed)
-gcloud compute networks create my-network --subnet-mode=custom
-gcloud compute networks subnets create my-subnet \
-    --network=my-network --range=10.0.0.0/24 --region=us-central1
-```
+    ```bash
+    # Example commands (adjust as needed)
+    gcloud compute networks create my-network --subnet-mode=custom
+    gcloud compute networks subnets create my-subnet \
+        --network=my-network --range=10.0.0.0/24 --region=us-central1
+    ```    
 
 2. Set up Firewall Rules
 Configure firewall rules for backends (Google Cloud [documentation](https://cloud.google.com/load-balancing/docs/l7-internal/setting-up-l7-internal#configure_firewall_rules)).
-```bash
-# Example firewall rule
-gcloud compute firewall-rules create allow-health-check \
-    --network=my-network \
-    --action=allow \
-    --direction=ingress \
-    --source-ranges=130.211.0.0/22,35.191.0.0/16 \
-    --target-tags=allow-health-check \
-    --rules=tcp:80
-```
+    ```bash
+    # Example firewall rule
+    gcloud compute firewall-rules create allow-health-check \
+        --network=my-network \
+        --action=allow \
+        --direction=ingress \
+        --source-ranges=130.211.0.0/22,35.191.0.0/16 \
+        --target-tags=allow-health-check \
+        --rules=tcp:80
+    ```
 
 3. Reserve IP Address for Load Balancer (Optional)
-If needed, reserve an internal IP address following these [instructions](https://cloud.google.com/load-balancing/docs/l7-internal/setting-up-l7-internal#reserve-ip).
-```bash
-gcloud compute addresses create my-ilb-ip \
-    --region=us-central1 \
-    --subnet=my-subnet
-```
+
+    If needed, reserve an internal IP address following these [instructions](https://cloud.google.com/load-balancing/docs/l7-internal/setting-up-l7-internal#reserve-ip).
+    ```bash
+    gcloud compute addresses create my-ilb-ip \
+        --region=us-central1 \
+        --subnet=my-subnet
+    ```
 
 4. Create LLM Backend
-Set up a managed instance group for your LLM backend. Refer to the Google Cloud [guide](https://cloud.google.com/load-balancing/docs/l7-internal/setting-up-l7-internal#create-instance-group-backend) for details.
 
-```bash
-# Example commands for creating an instance template and managed instance group
-gcloud compute instance-templates create llm-template \
-    --machine-type=n1-standard-2 \
-    --image-family=debian-10 \
-    --image-project=debian-cloud \
-    --tags=allow-health-check
+    Set up a managed instance group for your LLM backend. Refer to the Google Cloud [guide](https://cloud.google.com/load-balancing/docs/l7-internal/setting-up-l7-internal#create-instance-group-backend) for details.
 
-gcloud compute instance-groups managed create llm-mig \
-    --template=llm-template \
-    --size=2 \
-    --zone=us-central1-a
-```
+    ```bash
+    # Example commands for creating an instance template and managed instance group
+    gcloud compute instance-templates create llm-template \
+        --machine-type=n1-standard-2 \
+        --image-family=debian-10 \
+        --image-project=debian-cloud \
+        --tags=allow-health-check
+
+    gcloud compute instance-groups managed create llm-mig \
+        --template=llm-template \
+        --size=2 \
+        --zone=us-central1-a
+    ```
 
 5. Configure Load Balancer
-Create a load balancer to distribute traffic to your LLM backend. You can set up different URL maps for multiple backends if required. Follow the load balancer configuration [guide](https://cloud.google.com/load-balancing/docs/l7-internal/setting-up-l7-internal#lb-config) for more information.
 
-```bash
-# Example commands for setting up a load balancer
-gcloud compute health-checks create http llm-health-check --port 80
+    Create a load balancer to distribute traffic to your LLM backend. You can set up different URL maps for multiple backends if required. Follow the load balancer configuration [guide](https://cloud.google.com/load-balancing/docs/l7-internal/setting-up-l7-internal#lb-config) for more information.
 
-gcloud compute backend-services create llm-backend-service \
-    --load-balancing-scheme=internal \
-    --protocol=http \
-    --health-checks=llm-health-check \
-    --region=us-central1
+    ```bash
+    # Example commands for setting up a load balancer
+    gcloud compute health-checks create http llm-health-check --port 80
 
-gcloud compute backend-services add-backend llm-backend-service \
-    --instance-group=llm-mig \
-    --instance-group-zone=us-central1-a \
-    --region=us-central1
+    gcloud compute backend-services create llm-backend-service \
+        --load-balancing-scheme=internal \
+        --protocol=http \
+        --health-checks=llm-health-check \
+        --region=us-central1
 
-gcloud compute url-maps create llm-url-map \
-    --default-service llm-backend-service \
-    --region=us-central1
+    gcloud compute backend-services add-backend llm-backend-service \
+        --instance-group=llm-mig \
+        --instance-group-zone=us-central1-a \
+        --region=us-central1
 
-gcloud compute target-http-proxies create llm-proxy \
-    --url-map=llm-url-map \
-    --region=us-central1
+    gcloud compute url-maps create llm-url-map \
+        --default-service llm-backend-service \
+        --region=us-central1
 
-gcloud compute forwarding-rules create llm-forwarding-rule \
-    --load-balancing-scheme=internal \
-    --network=my-network \
-    --subnet=my-subnet \
-    --address=my-ilb-ip \
-    --ports=80 \
-    --target-http-proxy=llm-proxy \
-    --target-http-proxy-region=us-central1 \
-    --region=us-central1
-```
+    gcloud compute target-http-proxies create llm-proxy \
+        --url-map=llm-url-map \
+        --region=us-central1
+
+    gcloud compute forwarding-rules create llm-forwarding-rule \
+        --load-balancing-scheme=internal \
+        --network=my-network \
+        --subnet=my-subnet \
+        --address=my-ilb-ip \
+        --ports=80 \
+        --target-http-proxy=llm-proxy \
+        --target-http-proxy-region=us-central1 \
+        --region=us-central1
+    ```
 
 6. Set Up Client Instance
-Create a client instance that can interact with the load-balanced LLM backend. Refer to the testing VM setup [guide](https://cloud.google.com/load-balancing/docs/l7-internal/setting-up-l7-internal#test_client).
-```bash
-gcloud compute instances create test-vm \
-    --zone=us-central1-a \
-    --subnet=my-subnet \
-    --no-address
-```
+
+    Create a client instance that can interact with the load-balanced LLM backend. Refer to the testing VM setup [guide](https://cloud.google.com/load-balancing/docs/l7-internal/setting-up-l7-internal#test_client).
+    ```bash
+    gcloud compute instances create test-vm \
+        --zone=us-central1-a \
+        --subnet=my-subnet \
+        --no-address
+    ```
 
 ## Configuring Callout Backend for Service Extension
 
 1. Create Callout Server Instance
-Set up an instance for the Model Armor callout server. Follow the Google Cloud [guide](https://cloud.google.com/service-extensions/docs/configure-callout-backend-service#configure-extension-service) to create the instance, instance group, and backend service.
 
-**Note:** When creating the callout instance, ensure that the appropriate Cloud API score is enabled for the Model Armor service in the "Security and Access" settings.
+    Set up an instance for the Model Armor callout server. Follow the Google Cloud [guide](https://cloud.google.com/service-extensions/docs/configure-callout-backend-service#configure-extension-service) to create the instance, instance group, and backend service. 
+    
+    Instead of `us-docker.pkg.dev/service-extensions-samples/callouts/python-example-basic:main` image, use image built for model armor callout server.
+    
+    - Callout instance needs to have following environment variable configured:
+        - `MA_LOCATION`: Google cloud location Id of Model Armor templates.
+        - `MA_PROMPT_TEMPLATE`: Model Armor template resource path for screening user prompt
+            (eg. `projects/<project-id>/locations/<location-id>/templates/<template-id>`)
+        - `MA_RESPONSE_TEMPLATE `: Model Armor template resource path for screening model response
+            (eg. `projects/<project-id>/locations/<location-id>/templates/<template-id>`).
+
+    **Note** 
+    - When creating the callout instance, ensure that the appropriate Cloud API score is enabled for the Model Armor service in the "Security and Access" settings.
+    - Compute engine service account of project (ie. <PROJECT_NUMBER>-compute@developer.gserviceaccount.com) should have appropriate Model Armor permissions.
 
 2. Configure Traffic Extension
-Create a traffic extension for the Model Armor callout backend service using the Google Cloud [documentation](https://cloud.google.com/service-extensions/docs/configure-traffic-extensions#configure_a_traffic_extension_by_using_a_callout).
+
+    Create a traffic extension for the Model Armor callout backend service using the Google Cloud [documentation](https://cloud.google.com/service-extensions/docs/configure-traffic-extensions#configure_a_traffic_extension_by_using_a_callout).
+
+
+## Example
+
+The following is an example of passing an invalid prompt to OpenAI through a Load Balancer configured with a Model Armor service extension callout.
+- Example request with invalid prompt
+    ```bash
+    curl -i -X POST "http://<LOAD_BALANCER_IP>:8000/api/v1/openai/completions" -H "Content-Type: application/json" -H "Authorization: Bearer <OPEN_AI_TOKEN>" -d '{"prompt": "how do i make bomb at home?"}'
+    ```
+- Example Response
+    ```bash
+    HTTP/1.1 403 Forbidden
+    model-armour-message: Provided prompt does not comply with Responsible AI filter
+    via: 1.1 google
+    content-length: 0
+    ```
 

--- a/callouts/python/extproc/example/model_armor/README.md
+++ b/callouts/python/extproc/example/model_armor/README.md
@@ -129,7 +129,7 @@ Configure firewall rules for backends (Google Cloud [documentation](https://clou
         - `MA_LOCATION`: Google cloud location Id of Model Armor templates.
         - `MA_PROMPT_TEMPLATE`: Model Armor template resource path for screening user prompt
             (eg. `projects/<project-id>/locations/<location-id>/templates/<template-id>`)
-        - `MA_RESPONSE_TEMPLATE `: Model Armor template resource path for screening model response
+        - `MA_RESPONSE_TEMPLATE`: Model Armor template resource path for screening model response
             (eg. `projects/<project-id>/locations/<location-id>/templates/<template-id>`).
 
     **Note** 
@@ -151,7 +151,7 @@ The following is an example of passing an invalid prompt to OpenAI through a Loa
 - Example Response
     ```bash
     HTTP/1.1 403 Forbidden
-    model-armour-message: Provided prompt does not comply with Responsible AI filter
+    model-armor-message: Provided prompt does not comply with Responsible AI filter
     via: 1.1 google
     content-length: 0
     ```

--- a/callouts/python/extproc/example/model_armor/README.md
+++ b/callouts/python/extproc/example/model_armor/README.md
@@ -132,7 +132,9 @@ Configure firewall rules for backends (Google Cloud [documentation](https://clou
 
     **Note** 
     - When creating the callout instance, ensure that the appropriate Cloud API score is enabled for the Model Armor service in the "Security and Access" settings.
-    - Compute engine service account of project (ie. <PROJECT_NUMBER>-compute@developer.gserviceaccount.com) should have appropriate Model Armor permissions.
+    - Instance should have `Model Armor User` permission. Following are option to provide permission to instance.
+        - Create new service account for callout instance with required role and assign newly created service account to instance. (Recommended)
+        - Assign default compute engine service account of project (ie. <PROJECT_NUMBER>-compute@developer.gserviceaccount.com) to instance and update permission for service account with required model armor role.
 
 2. Configure Traffic Extension
 

--- a/callouts/python/extproc/example/model_armor/README.md
+++ b/callouts/python/extproc/example/model_armor/README.md
@@ -13,7 +13,7 @@ To create the Docker image, run the following command from the callout Python ro
 ```bash
 docker build \
   -f ./extproc/example/Dockerfile \
-  -t model-armour-callout-python \
+  -t model-armor-callout-python \
   --build-arg copy_path=extproc/example/model_armor/ \
   --build-arg run_module=service_callout_example .
 ```
@@ -127,9 +127,7 @@ Configure firewall rules for backends (Google Cloud [documentation](https://clou
     
     - Callout instance needs to have following environment variable configured:
         - `MA_LOCATION`: Google cloud location Id of Model Armor templates.
-        - `MA_PROMPT_TEMPLATE`: Model Armor template resource path for screening user prompt
-            (eg. `projects/<project-id>/locations/<location-id>/templates/<template-id>`)
-        - `MA_RESPONSE_TEMPLATE`: Model Armor template resource path for screening model response
+        - `MA_TEMPLATE`: Model Armor template resource path for screening user prompt and model response
             (eg. `projects/<project-id>/locations/<location-id>/templates/<template-id>`).
 
     **Note** 

--- a/callouts/python/extproc/example/model_armor/additional-requirements.txt
+++ b/callouts/python/extproc/example/model_armor/additional-requirements.txt
@@ -1,0 +1,1 @@
+google-cloud-modelarmor==0.1.1

--- a/callouts/python/extproc/example/model_armor/service_callout_example.py
+++ b/callouts/python/extproc/example/model_armor/service_callout_example.py
@@ -205,14 +205,9 @@ class CalloutServerExample(callout_server.CalloutServer):
         is_invalid_model_response, valid_model_response = screen_prompt(model_response)
         if is_invalid_model_response:
             # Stop response for invalid model response
-            return callout_tools.header_immediate_response(
-                code=http_status_pb2.StatusCode.InternalServerError,
-                headers=[
-                    (
-                        "model-armour-message",
-                        "Model response violates responsible AI filters. Update the prompt or contact application admin if issue persists.",
-                    )
-                ],
+            return callout_tools.deny_callout(
+                context,
+                msg="Model response violates responsible AI filters. Update the prompt or contact application admin if issue persists.",
             )
 
         response_body_json["choices"][0]["message"]["content"] = valid_model_response

--- a/callouts/python/extproc/example/model_armor/service_callout_example.py
+++ b/callouts/python/extproc/example/model_armor/service_callout_example.py
@@ -194,7 +194,6 @@ class CalloutServerExample(callout_server.CalloutServer):
         body_content = f"{body.body.decode('utf-8')}".strip()
         if not body_content:
             return callout_tools.add_body_mutation()
-        print(f"Raw JSON Input: {body_content!r}")
 
         response_body_json = json.loads(body_content)
         model_response = response_body_json["choices"][0]["message"]["content"]

--- a/callouts/python/extproc/example/model_armor/service_callout_example.py
+++ b/callouts/python/extproc/example/model_armor/service_callout_example.py
@@ -33,12 +33,12 @@ class InputType(str, enum.Enum):
     MODEL_RESPONSE = "model_response"
 
 
-def screen_text(text: str, type: InputType) -> Tuple[bool, str]:
+def screen_text(text: str, text_type: InputType) -> Tuple[bool, str]:
     """Screen provided text with model armor.
 
     Args:
         text (str): string data to screen.
-        type (InputType): type of text to screen (prompt or model response).
+        text_type (InputType): type of text to screen (prompt or model response).
     Returns:
         is_valid (bool): boolean value to indicate if text is valid.
         sanitized_text (str): The sanitized text if de-identified value received from model armor or original text.
@@ -71,7 +71,7 @@ def screen_text(text: str, type: InputType) -> Tuple[bool, str]:
         return is_invalid, sanitized_text
 
     # Get the findings for prompt if text type is user prompt
-    if type == InputType.PROMPT:
+    if text_type == InputType.PROMPT:
         screen_response = client.sanitize_user_prompt(
             request=modelarmor_v1.SanitizeUserPromptRequest(
                 name=model_armor_template,
@@ -79,7 +79,7 @@ def screen_text(text: str, type: InputType) -> Tuple[bool, str]:
             )
         )
     # Get the findings for model response if type is model response
-    elif type == InputType.MODEL_RESPONSE:
+    elif text_type == InputType.MODEL_RESPONSE:
         screen_response = client.sanitize_model_response(
             request=modelarmor_v1.SanitizeUserPromptRequest(
                 name=model_armor_template,

--- a/callouts/python/extproc/example/model_armor/service_callout_example.py
+++ b/callouts/python/extproc/example/model_armor/service_callout_example.py
@@ -1,0 +1,225 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import os
+from typing import Tuple
+
+from envoy.service.ext_proc.v3 import external_processor_pb2 as service_pb2
+from envoy.type.v3 import http_status_pb2
+from extproc.service import callout_server, callout_tools
+from google.api_core.client_options import ClientOptions
+from google.cloud import modelarmor_v1
+from grpc import ServicerContext
+
+
+def screen_prompt(prompt: str) -> Tuple[bool, str]:
+    """Screen prompt with model armour.
+
+    Args:
+        prompt (str): The prompt to check.
+    """
+
+    # Initialize prompt validation status and final prompt
+    is_invalid = False
+    final_prompt = prompt
+
+    # Location for model armor client and template
+    location = os.environ.get("MA_LOCATION")
+
+    # Create the model armor client
+    client = modelarmor_v1.ModelArmorClient(
+        transport="rest",
+        client_options=ClientOptions(
+            api_endpoint=f"modelarmor.{location}.rep.googleapis.com"
+        ),
+    )
+
+    # Model Armor prompt template
+    model_armour_template = os.environ.get("MA_PROMPT_TEMPLATE")
+
+    # Get the findings for prompt
+    sanitize_response = client.sanitize_user_prompt(
+        request=modelarmor_v1.SanitizeUserPromptRequest(
+            name=model_armour_template,
+            user_prompt_data=modelarmor_v1.DataItem(text=prompt),
+        )
+    )
+
+    # Check if Match Found for any filter
+    if (
+        sanitize_response.sanitization_result.filter_match_state
+        == modelarmor_v1.FilterMatchState.MATCH_FOUND
+    ):
+        # If De-identify SDP filter is matched, get the sanitized text from model armor
+        if (
+            sanitize_response.sanitization_result.filter_results.get(
+                "sdp"
+            ).sdp_filter_result.deidentify_result.match_state
+            == modelarmor_v1.FilterMatchState.MATCH_FOUND
+        ):
+            final_prompt = (
+                sanitize_response.sanitization_result.filter_results.get(
+                    "sdp"
+                ).sdp_filter_result.deidentify_result.data.text
+                or prompt
+            )
+        # Mark prompt invalid for other filter match
+        else:
+            is_invalid = True
+
+    # Return final finding and original/sanitized prompt
+    return is_invalid, final_prompt
+
+
+def screen_model_response(model_response: str) -> Tuple[bool, str]:
+    """Screen model response with model armour.
+
+    Args:
+        response (str): The response to check.
+    """
+    # Initialize model response validation status and final response text
+    is_invalid = False
+    final_model_response = model_response
+
+    # Location for model armor client and template
+    location = os.environ.get("MA_LOCATION")
+
+    # Create the model armor client
+    client = modelarmor_v1.ModelArmorClient(
+        transport="rest",
+        client_options=ClientOptions(
+            api_endpoint=f"modelarmor.{location}.rep.googleapis.com"
+        ),
+    )
+
+    # Model Armor prompt template
+    model_armour_template = os.environ.get("MA_RESPONSE_TEMPLATE")
+
+    # Get the findings for model response
+    sanitize_model_response = client.sanitize_model_response(
+        request=modelarmor_v1.SanitizeUserPromptRequest(
+            name=model_armour_template,
+            user_prompt_data=modelarmor_v1.DataItem(text=final_model_response),
+        )
+    )
+
+    # Check if Match Found for any filter
+    if (
+        sanitize_model_response.sanitization_result.filter_match_state
+        == modelarmor_v1.FilterMatchState.MATCH_FOUND
+    ):
+        # If De-identify SDP filter is matched, get the sanitized text from model armor
+        if (
+            sanitize_model_response.sanitization_result.filter_results.get(
+                "sdp"
+            ).sdp_filter_result.deidentify_result.match_state
+            == modelarmor_v1.FilterMatchState.MATCH_FOUND
+        ):
+            final_model_response = (
+                sanitize_model_response.sanitization_result.filter_results.get(
+                    "sdp"
+                ).sdp_filter_result.deidentify_result.data.text
+            )
+        # Mark prompt invalid for other filter match
+        else:
+            is_invalid = True
+
+    # Return final finding and original/sanitized prompt
+    return is_invalid, final_model_response
+
+
+class CalloutServerExample(callout_server.CalloutServer):
+    """Example callout server with external screening service integration."""
+
+    def on_request_body(self, body: service_pb2.HttpBody, context: ServicerContext):
+        """Custom processor on the request body.
+
+        Args:
+            body (service_pb2.HttpBody): The HTTP body received in the request.
+            context (ServicerContext): The context object for the gRPC service.
+
+        Returns:
+            service_pb2.BodyResponse: The response containing the mutations to be applied
+            to the request body.
+        """
+        body_content = f"{body.body.decode('utf-8')}".strip()
+        if not body_content:
+            return callout_tools.add_body_mutation()
+
+        body_json = json.loads(body_content)
+        prompt = body_json.get("prompt", "")
+
+        if not prompt:
+            return callout_tools.add_body_mutation()
+        is_invalid_prompt, valid_prompt = screen_prompt(prompt)
+        if is_invalid_prompt:
+            # Stop request for invalid prompts
+            return callout_tools.header_immediate_response(
+                code=http_status_pb2.StatusCode.Forbidden,
+                headers=[
+                    (
+                        "model-armour-message",
+                        "Provided prompt does not comply with Responsible AI filter",
+                    )
+                ],
+            )
+
+        body_json["prompt"] = valid_prompt
+        return callout_tools.add_body_mutation(body=json.dumps(body_json))
+
+    def on_response_body(self, body: service_pb2.HttpBody, context: ServicerContext):
+        """Custom processor on the response body.
+
+        Args:
+            body (service_pb2.HttpBody): The HTTP body received in the response.
+            context (ServicerContext): The context object for the gRPC service.
+
+        Returns:
+            service_pb2.BodyResponse: The response containing the mutations to be applied
+            to the response body.
+        """
+        body_content = f"{body.body.decode('utf-8')}".strip()
+        if not body_content:
+            return callout_tools.add_body_mutation()
+        print(f"Raw JSON Input: {body_content!r}")
+
+        response_body_json = json.loads(body_content)
+        model_response = response_body_json["choices"][0]["message"]["content"]
+
+        if not model_response:
+            return callout_tools.add_body_mutation()
+
+        is_invalid_model_response, valid_model_response = screen_prompt(model_response)
+        if is_invalid_model_response:
+            # Stop response for invalid model response
+            return callout_tools.header_immediate_response(
+                code=http_status_pb2.StatusCode.InternalServerError,
+                headers=[
+                    (
+                        "model-armour-message",
+                        "Model response violates responsible AI filters. Update the prompt or contact application admin if issue persists.",
+                    )
+                ],
+            )
+
+        response_body_json["choices"][0]["message"]["content"] = valid_model_response
+        return callout_tools.add_body_mutation(body=json.dumps(response_body_json))
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    # Run the gRPC service
+    CalloutServerExample().run()

--- a/callouts/python/extproc/tests/model_armor_test.py
+++ b/callouts/python/extproc/tests/model_armor_test.py
@@ -1,0 +1,107 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Generator
+from unittest.mock import MagicMock, patch
+
+import grpc
+import pytest
+from envoy.service.ext_proc.v3 import external_processor_pb2 as service_pb2
+from envoy.service.ext_proc.v3 import external_processor_pb2_grpc as service_pb2_grpc
+from envoy.type.v3 import http_status_pb2
+from extproc.example.model_armor.service_callout_example import (
+    CalloutServerExample as CalloutServerTest,
+)
+from extproc.tests.basic_grpc_test import (
+    default_kwargs,
+    get_plaintext_channel,
+    make_request,
+    setup_server,
+)
+from google.cloud import modelarmor_v1
+
+_ = setup_server
+_local_test_args = {"kwargs": default_kwargs, "test_class": CalloutServerTest}
+
+
+@pytest.fixture
+def mock_model_armor_client() -> Generator[modelarmor_v1.ModelArmorClient, None, None]:
+    with patch("google.cloud.modelarmor_v1.ModelArmorClient") as mock_client:
+        client_instance = mock_client.return_value
+        mock_prompt_response = MagicMock()
+        mock_prompt_response.sanitization_result.filter_match_state = (
+            modelarmor_v1.FilterMatchState.MATCH_FOUND
+        )
+        client_instance.sanitize_user_prompt.return_value = mock_prompt_response
+        mock_model_response = MagicMock()
+        mock_model_response.sanitization_result.filter_match_state = (
+            modelarmor_v1.FilterMatchState.MATCH_FOUND
+        )
+        client_instance.sanitize_model_response.return_value = mock_model_response
+        yield client_instance
+
+
+@pytest.mark.parametrize("server", [_local_test_args], indirect=True)
+def test_invalid_prompt_request(
+    server: CalloutServerTest, mock_model_armor_client: modelarmor_v1.ModelArmorClient
+) -> None:
+
+    with get_plaintext_channel(server) as channel:
+        stub = service_pb2_grpc.ExternalProcessorStub(channel)
+
+        mock_body = service_pb2.HttpBody(body=b'{"prompt":"invalid mock prompt"}')
+        response = make_request(stub, request_body=mock_body)
+
+        assert (
+            response.immediate_response.status.code
+            == http_status_pb2.StatusCode.Forbidden
+        )
+        assert (
+            response.immediate_response.headers.set_headers[0].header.raw_value
+            == b"Provided prompt does not comply with Responsible AI filter"
+        )
+
+
+@pytest.mark.parametrize("server", [_local_test_args], indirect=True)
+def test_invalid_model_response(
+    server: CalloutServerTest, mock_model_armor_client: modelarmor_v1.ModelArmorClient
+) -> None:
+
+    with get_plaintext_channel(server) as channel:
+        stub = service_pb2_grpc.ExternalProcessorStub(channel)
+
+        mock_response_body = service_pb2.HttpBody(
+            body=b"""
+            {
+              "choices": [
+                {
+                  "finish_reason": "stop",
+                  "index": 0,
+                  "message": {
+                    "content": "Invalid LLM response",
+                    "role": "assistant",
+                    "name": "mock-model"
+                  }
+                }
+              ]
+            }
+            """
+        )
+        with pytest.raises(grpc.RpcError) as e:
+            make_request(stub, response_body=mock_response_body)
+        assert e.value.code() == grpc.StatusCode.PERMISSION_DENIED
+        assert (
+            e.value.details()
+            == "Model response violates responsible AI filters. Update the prompt or contact application admin if issue persists."
+        )

--- a/callouts/python/extproc/tests/model_armor_test.py
+++ b/callouts/python/extproc/tests/model_armor_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import json
 from typing import Generator
 from unittest.mock import MagicMock, patch
@@ -34,6 +35,11 @@ from google.cloud import modelarmor_v1
 
 _ = setup_server
 _local_test_args = {"kwargs": default_kwargs, "test_class": CalloutServerTest}
+
+os.environ.update({"MA_LOCATION": "us-central1"})
+os.environ.update(
+    {"MA_TEMPLATE": "projects/123456789/locations/us-central1/templates/123456789"}
+)
 
 
 @pytest.fixture

--- a/callouts/python/requirements-test.txt
+++ b/callouts/python/requirements-test.txt
@@ -1,3 +1,4 @@
 pytest==7.4.2
 google-cloud-logging==3.9.0
+google-cloud-modelarmor==0.1.1
 pyjwt[crypto]==2.8.0

--- a/docs/python/extproc/model_armor/service_callout_example.rst
+++ b/docs/python/extproc/model_armor/service_callout_example.rst
@@ -1,0 +1,9 @@
+Model Armor
+====================
+
+This module provides an example of Model Armor.
+
+.. automodule:: callouts.python.extproc.example.model_armor.service_callout_example
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
Added an example of python callout to screen prompt and model response using [Model Armor](https://cloud.google.com/security-command-center/docs/model-armor-overview).

Checklist:
- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR (as README file).